### PR TITLE
for loops first and last can now be non int literal

### DIFF
--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -1244,17 +1244,7 @@ fn codegenFor(context: *Context, entity: Entity) !void {
         }
         panic("\nfor range unsupported type {s}\n", .{literalOf(type_of)});
     };
-    {
-        const first = try context.codebase.createEntity(.{
-            components.Type.init(builtins[i]),
-            iterator.get(components.First).entity.get(components.Literal),
-        });
-        const wasm_instruction = try context.codebase.createEntity(.{
-            kinds[i],
-            components.Constant.init(first),
-        });
-        _ = try context.wasm_instructions.append(wasm_instruction);
-    }
+    try codegenEntity(context, iterator.get(components.First).entity);
     {
         const wasm_instruction = try context.codebase.createEntity(.{
             components.WasmInstructionKind.local_set,

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -355,14 +355,24 @@ fn parseDefineOrRange(codebase: *ECS, tokens: *Tokens, lhs: Entity, precedence: 
     switch (kind) {
         .symbol => {
             const type_ast = try parseExpression(codebase, tokens, DEFINE + NEXT_PRECEDENCE);
-            _ = tokens.consume(.equal);
-            const value = try parseExpression(codebase, tokens, precedence);
+            if (tokens.peek()) |token| {
+                if (token.get(components.TokenKind) == .equal) {
+                    _ = tokens.next();
+                    const value = try parseExpression(codebase, tokens, precedence);
+                    return try codebase.createEntity(.{
+                        components.AstKind.define,
+                        components.Name.init(lhs),
+                        components.TypeAst.init(type_ast),
+                        components.Value.init(value),
+                        components.Span.init(lhs.get(components.Span).begin, value.get(components.Span).end),
+                    });
+                }
+            }
             return try codebase.createEntity(.{
-                components.AstKind.define,
-                components.Name.init(lhs),
-                components.TypeAst.init(type_ast),
-                components.Value.init(value),
-                components.Span.init(lhs.get(components.Span).begin, value.get(components.Span).end),
+                components.AstKind.range,
+                components.Span.init(lhs.get(components.Span).begin, type_ast.get(components.Span).end),
+                components.First.init(lhs),
+                components.Last.init(type_ast),
             });
         },
         .int => {

--- a/src/semantic_analyzer.zig
+++ b/src/semantic_analyzer.zig
@@ -1013,6 +1013,7 @@ fn Context(comptime FileSystem: type) type {
                 } else {
                     const interned = try self.codebase.getPtr(Strings).intern("0");
                     break :blk try self.codebase.createEntity(.{
+                        components.AstKind.int,
                         components.Literal.init(interned),
                         components.Type.init(b.IntLiteral),
                     });

--- a/src/tests/test_for.zig
+++ b/src/tests/test_for.zig
@@ -332,30 +332,6 @@ test "codegen for loop" {
     // TODO: test that proper for loop instructions are generated
 }
 
-test "codegen for loop with non int literal last" {
-    var arena = Arena.init(std.heap.page_allocator);
-    defer arena.deinit();
-    var codebase = try initCodebase(&arena);
-    var fs = try MockFileSystem.init(&arena);
-    _ = try fs.newFile("foo.yeti",
-        \\start(): i32 {
-        \\  sum = 0
-        \\  n = 10
-        \\  for i in 0:n {
-        \\    sum += i
-        \\  }
-        \\  sum 
-        \\}
-    );
-    const module = try analyzeSemantics(codebase, fs, "foo.yeti");
-    try codegen(module);
-    const top_level = module.get(components.TopLevel);
-    const start = top_level.findString("start").get(components.Overloads).slice()[0];
-    const start_instructions = start.get(components.WasmInstructions).slice();
-    try expectEqual(start_instructions.len, 22);
-    // TODO: test that proper for loop instructions are generated
-}
-
 test "print wasm for loop" {
     var arena = Arena.init(std.heap.page_allocator);
     defer arena.deinit();
@@ -517,6 +493,109 @@ test "print wasm for loop non int literal last implicit range start" {
         \\  sum = 0
         \\  n = 10
         \\  for i in :n {
+        \\    sum += 1
+        \\  }
+        \\  sum
+        \\}
+    );
+    const module = try analyzeSemantics(codebase, fs, "foo.yeti");
+    try codegen(module);
+    const wasm = try printWasm(module);
+    try expectEqualStrings(wasm,
+        \\(module
+        \\
+        \\  (func $foo/start (result i64)
+        \\    (local $sum i64)
+        \\    (local $i i32)
+        \\    (i64.const 0)
+        \\    (local.set $sum)
+        \\    (i32.const 0)
+        \\    (local.set $i)
+        \\    block $.label.0
+        \\    loop $.label.1
+        \\    (local.get $i)
+        \\    (i32.const 10)
+        \\    i32.ge_s
+        \\    br_if $.label.0
+        \\    (local.get $sum)
+        \\    (i64.const 1)
+        \\    i64.add
+        \\    (local.set $sum)
+        \\    (i32.const 1)
+        \\    (local.get $i)
+        \\    i32.add
+        \\    (local.set $i)
+        \\    br $.label.1
+        \\    end $.label.1
+        \\    end $.label.0
+        \\    (local.get $sum))
+        \\
+        \\  (export "_start" (func $foo/start)))
+    );
+}
+
+test "print wasm for loop non int literal first" {
+    var arena = Arena.init(std.heap.page_allocator);
+    defer arena.deinit();
+    var codebase = try initCodebase(&arena);
+    var fs = try MockFileSystem.init(&arena);
+    _ = try fs.newFile("foo.yeti",
+        \\start(): i64 {
+        \\  sum = 0
+        \\  n = 0
+        \\  for i in n:10 {
+        \\    sum += 1
+        \\  }
+        \\  sum
+        \\}
+    );
+    const module = try analyzeSemantics(codebase, fs, "foo.yeti");
+    try codegen(module);
+    const wasm = try printWasm(module);
+    try expectEqualStrings(wasm,
+        \\(module
+        \\
+        \\  (func $foo/start (result i64)
+        \\    (local $sum i64)
+        \\    (local $i i32)
+        \\    (i64.const 0)
+        \\    (local.set $sum)
+        \\    (i32.const 0)
+        \\    (local.set $i)
+        \\    block $.label.0
+        \\    loop $.label.1
+        \\    (local.get $i)
+        \\    (i32.const 10)
+        \\    i32.ge_s
+        \\    br_if $.label.0
+        \\    (local.get $sum)
+        \\    (i64.const 1)
+        \\    i64.add
+        \\    (local.set $sum)
+        \\    (i32.const 1)
+        \\    (local.get $i)
+        \\    i32.add
+        \\    (local.set $i)
+        \\    br $.label.1
+        \\    end $.label.1
+        \\    end $.label.0
+        \\    (local.get $sum))
+        \\
+        \\  (export "_start" (func $foo/start)))
+    );
+}
+
+test "print wasm for loop non int literal first and last" {
+    var arena = Arena.init(std.heap.page_allocator);
+    defer arena.deinit();
+    var codebase = try initCodebase(&arena);
+    var fs = try MockFileSystem.init(&arena);
+    _ = try fs.newFile("foo.yeti",
+        \\start(): i64 {
+        \\  sum = 0
+        \\  first = 0
+        \\  last = 10
+        \\  for i in first:last {
         \\    sum += 1
         \\  }
         \\  sum


### PR DESCRIPTION
This syntax is now supported

```yeti
start() {
  first = 0
  last = 10
  sum = 0
  for i in first:last {
    sum += i
  }
  sum
}
```